### PR TITLE
Hide fields in task, using a dictionary instead of False or -1.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
+- Hide fields in task, using a dictionary instead of False or -1.
+  [Julian Infanger]
+
 - onegov.ch approved: add badge to readme.
   [jone]
 

--- a/ftw/task/content/task.py
+++ b/ftw/task/content/task.py
@@ -118,7 +118,8 @@ hide_fields = ['description',
 
 for item in hide_fields:
     TaskSchema.changeSchemataForField(item, 'default')
-    TaskSchema[item].widget.visible = False
+    TaskSchema[item].widget.visible = {'edit':'invisible',
+                                       'view':'invisible'}
 
 
 class Task(document.ATDocument):


### PR DESCRIPTION
@jone Otherwise there is an error caused in DiscussionTool (allowDiscussion returns a string):
ValueError: invalid literal for int() with base 10: ''
