### PR TITLE
Updated translation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Updated translation.
+  [Julian Infanger]
 
 
 2.4.2 (2013-01-30)

--- a/ftw/task/locales/de/LC_MESSAGES/ftw.task.po
+++ b/ftw/task/locales/de/LC_MESSAGES/ftw.task.po
@@ -99,7 +99,7 @@ msgstr "Zuständigkeit"
 #: ./ftw/task/content/task.py:55
 #, fuzzy
 msgid "task_help_end_date"
-msgstr "Geben Sie das Enddatum ein oder klicken Sie auf das Kalender Icon um ein Datum auszuwählen."
+msgstr "Geben Sie das Enddatum ein oder klicken Sie auf das Kalendersymbol um ein Datum auszuwählen."
 
 #: ./ftw/task/content/task.py:88
 msgid "task_help_related_items"


### PR DESCRIPTION
@maethu Replaced "Kalender Icon" with "Kalendersymbol" in german translation.
