### PR TITLE
Fix responsible field in tabbed view for contacts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Changelog
 
 - Drop Plone 4.1 and 4.2 support. [jone]
 
+- Fix responsible field in tabbed view for contacts. [lknoepfel]
+
 
 2.4.7 (2014-09-15)
 ------------------

--- a/ftw/task/browser/tasktab.py
+++ b/ftw/task/browser/tasktab.py
@@ -1,6 +1,14 @@
 from ftw.tabbedview.browser import listing
 from ftw.table import helper
+from ftw.task.browser.task import getUserInfos
 from ftw.task import _
+from plone import api
+
+
+def readable_responsible(item, persons):
+    portal = api.portal.get()
+    return ', '.join(
+        [getUserInfos(portal, person)['name'] for person in persons])
 
 
 class TaskTab(listing.CatalogListingView):
@@ -30,7 +38,7 @@ class TaskTab(listing.CatalogListingView):
         {'column': 'getResponsibility',
          'column_title': _(u'label_taskstab_responsibility',
                            default=u'Responsibility'),
-         'transform': helper.readable_author},
+         'transform': readable_responsible},
 
         {'column': 'review_state',
          'column_title': _(u'label_taskstab_review_state',

--- a/ftw/task/testing.py
+++ b/ftw/task/testing.py
@@ -11,6 +11,7 @@ from plone.app.testing import setRoles, TEST_USER_ID, TEST_USER_NAME, login
 from plone.testing import z2
 from zope.configuration import xmlconfig
 import ftw.task.tests.builders
+import egov.contactdirectory.tests.builders
 
 
 class ZCMLLayer(ComponentRegistryLayer):
@@ -38,10 +39,12 @@ class FtwTaskLayer(PloneSandboxLayer):
             context=configurationContext)
 
         z2.installProduct(app, 'ftw.task')
+        z2.installProduct(app, 'egov.contactdirectory')
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.task:default')
         applyProfile(portal, 'ftw.tabbedview:default')
+        applyProfile(portal, 'egov.contactdirectory:default')
 
         setRoles(portal, TEST_USER_ID, ['Manager'])
         login(portal, TEST_USER_NAME)

--- a/ftw/task/tests/test_task_tab.py
+++ b/ftw/task/tests/test_task_tab.py
@@ -20,12 +20,15 @@ class TestTaskTab(TestCase):
                                       ('one_state_workflow',))
 
         self.john = create(Builder('user'))
+        self.bert = create(Builder('contact')
+                           .having(firstname='Bert', lastname='Bort'))
 
         self.task = create(Builder('task')
                            .titled('My task')
                            .having(text='<p>Text</p>')
                            .having(end_date=DateTime('2010/05/05'))
-                           .having(responsibility=self.john.getId()))
+                           .having(responsibility=(self.john.getId(),
+                                                   self.bert.UID())))
 
     @browsing
     def test_task_tab(self, browser):
@@ -35,7 +38,7 @@ class TestTaskTab(TestCase):
             [['Title', 'End', 'Responsibility', 'State', 'Creator'],
              [self.task.Title(),
               '05.05.2010 00:00',
-              self.john.getProperty('fullname'),
+              'Doe John, Bort Bert',
               'published',
               'test_user_1_']],
             browser.css('.listing').first.lists())

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ tests_require = [
     'ftw.pdfgenerator',
     'ftw.tabbedview',
     'ftw.table',
+    'egov.contactdirectory',
     ]
 
 extras_require = {

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,3 +3,4 @@ extends = http://plonesource.org/sources.cfg
 extensions = mr.developer
 
 auto-checkout =
+    egov.contactdirectory


### PR DESCRIPTION
In izug.onegov you can select contacts (`egov.contactdirectory`) as responsible entities. `ftw.task` expects a user and since it can't find a user will display the `uid` of the contact:
![screen shot 2016-11-17 at 10 40 19](https://cloud.githubusercontent.com/assets/1375745/20384056/9267cada-acb2-11e6-81cd-8b1ca0802bee.png)

This PR changes the transform to the same function used by the task detail view.

![screen shot 2016-11-17 at 10 38 22](https://cloud.githubusercontent.com/assets/1375745/20384113/d1b77488-acb2-11e6-9454-d0d3deb1d92d.png)
