### PR TITLE
Workaround for "Products.PloneHotfix20160830".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Workaround for adding portlets when "Products.PloneHotfix20160830" (1.3) is
+  installed. [mbaechtold]
 
 
 3.0.0 (2016-11-21)

--- a/ftw/task/portlets/mytasks.py
+++ b/ftw/task/portlets/mytasks.py
@@ -76,3 +76,6 @@ class AddForm(base.NullAddForm):
 
     def create(self):
         return Assignment()
+
+    def referer(self):
+        return self.request.get('referer', '')


### PR DESCRIPTION
"Products.PloneHotfix20160830" (1.3) patches `nextURL()` of `NullAddForm`. It reads the referer from a class attribute instead of the request.

This can be worked around by providing a method `referer()` on the class.